### PR TITLE
Fix PCRE callout with # delimiters

### DIFF
--- a/Swift.tmLanguage.json
+++ b/Swift.tmLanguage.json
@@ -2426,7 +2426,7 @@
 
     "literals-regular-expression-literal-callout": {
       "name": "meta.callout.regexp",
-      "match": "(?x)\n# PCRECallout\n(\\()(?<keyw>\\?C)\n  (?:\n    (?<num>\\d+)\n    | `(?<name>(?:[^`]|``)*)`\n    | '(?<name>(?:[^']|'')*)'\n    | \"(?<name>(?:[^\"]|\"\")*)\"\n    | \\^(?<name>(?:[^\\^]|\\^\\^)*)\\^\n    | %(?<name>(?:[^%]|%%)*)%\n    | #(?<name>(?:[^#]|##)*)#\n    | \\$(?<name>(?:[^$]|\\$\\$)*)\\$\n    | \\{(?<name>(?:[^}]|\\}\\})*)\\}\n  )?\n(\\))\n# NamedCallout\n| (\\()(?<keyw>\\*)\n    (?<name>(?!\\d)\\w+)\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?:\\{ [^,}]+ (?:,[^,}]+)* \\})?\n  (\\))\n# InterpolatedCallout\n| (\\()(?<keyw>\\?)\n    # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces\n    (\\{(?<g1>\\{)?+(?<g2>\\{)?+(?<g3>\\{)?+(?<g4>\\{)?+(?<g5>\\{)?+) .+? \\}(?(<g1>)\\})(?(<g2>)\\})(?(<g3>)\\})(?(<g4>)\\})(?(<g5>)\\})\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?<keyw>[X<>]?)\n  (\\))",
+      "match": "(?x)\n# PCRECallout\n(\\()(?<keyw>\\?C)\n  (?:\n    (?<num>\\d+)\n    | `(?<name>(?:[^`]|``)*)`\n    | '(?<name>(?:[^']|'')*)'\n    | \"(?<name>(?:[^\"]|\"\")*)\"\n    | \\^(?<name>(?:[^\\^]|\\^\\^)*)\\^\n    | %(?<name>(?:[^%]|%%)*)%\n    | \\#(?<name>(?:[^#]|\\#\\#)*)\\#\n    | \\$(?<name>(?:[^$]|\\$\\$)*)\\$\n    | \\{(?<name>(?:[^}]|\\}\\})*)\\}\n  )?\n(\\))\n# NamedCallout\n| (\\()(?<keyw>\\*)\n    (?<name>(?!\\d)\\w+)\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?:\\{ [^,}]+ (?:,[^,}]+)* \\})?\n  (\\))\n# InterpolatedCallout\n| (\\()(?<keyw>\\?)\n    # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces\n    (\\{(?<g1>\\{)?+(?<g2>\\{)?+(?<g3>\\{)?+(?<g4>\\{)?+(?<g5>\\{)?+) .+? \\}(?(<g1>)\\})(?(<g2>)\\})(?(<g3>)\\})(?(<g4>)\\})(?(<g5>)\\})\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?<keyw>[X<>]?)\n  (\\))",
       "captures": {
         "1": { "name": "punctuation.definition.group.regexp" },
         "2": { "name": "keyword.control.callout.regexp" },
@@ -2438,17 +2438,18 @@
         "8": { "name": "entity.name.function.callout.regexp" },
         "9": { "name": "entity.name.function.callout.regexp" },
         "10": { "name": "entity.name.function.callout.regexp" },
-        "11": { "name": "punctuation.definition.group.regexp" },
+        "11": { "name": "entity.name.function.callout.regexp" },
         "12": { "name": "punctuation.definition.group.regexp" },
-        "13": { "name": "keyword.control.callout.regexp" },
-        "14": { "name": "entity.name.function.callout.regexp" },
-        "15": { "name": "variable.language.tag-name.regexp" },
-        "16": { "name": "punctuation.definition.group.regexp" },
+        "13": { "name": "punctuation.definition.group.regexp" },
+        "14": { "name": "keyword.control.callout.regexp" },
+        "15": { "name": "entity.name.function.callout.regexp" },
+        "16": { "name": "variable.language.tag-name.regexp" },
         "17": { "name": "punctuation.definition.group.regexp" },
-        "18": { "name": "keyword.control.callout.regexp" },
-        "25": { "name": "variable.language.tag-name.regexp" },
-        "26": { "name": "keyword.control.callout.regexp" },
-        "27": { "name": "punctuation.definition.group.regexp" }
+        "18": { "name": "punctuation.definition.group.regexp" },
+        "19": { "name": "keyword.control.callout.regexp" },
+        "26": { "name": "variable.language.tag-name.regexp" },
+        "27": { "name": "keyword.control.callout.regexp" },
+        "28": { "name": "punctuation.definition.group.regexp" }
       }
     },
 

--- a/Swift.tmLanguage.yaml
+++ b/Swift.tmLanguage.yaml
@@ -1977,7 +1977,7 @@ repository:
           | "(?<name>(?:[^"]|"")*)"
           | \^(?<name>(?:[^\^]|\^\^)*)\^
           | %(?<name>(?:[^%]|%%)*)%
-          | #(?<name>(?:[^#]|##)*)#
+          | \#(?<name>(?:[^#]|\#\#)*)\#
           | \$(?<name>(?:[^$]|\$\$)*)\$
           | \{(?<name>(?:[^}]|\}\})*)\}
         )?
@@ -2006,17 +2006,18 @@ repository:
       8: { name: entity.name.function.callout.regexp }
       9: { name: entity.name.function.callout.regexp }
       10: { name: entity.name.function.callout.regexp }
-      11: { name: punctuation.definition.group.regexp }
+      11: { name: entity.name.function.callout.regexp }
       12: { name: punctuation.definition.group.regexp }
-      13: { name: keyword.control.callout.regexp }
-      14: { name: entity.name.function.callout.regexp }
-      15: { name: variable.language.tag-name.regexp }
-      16: { name: punctuation.definition.group.regexp }
+      13: { name: punctuation.definition.group.regexp }
+      14: { name: keyword.control.callout.regexp }
+      15: { name: entity.name.function.callout.regexp }
+      16: { name: variable.language.tag-name.regexp }
       17: { name: punctuation.definition.group.regexp }
-      18: { name: keyword.control.callout.regexp }
-      25: { name: variable.language.tag-name.regexp }
-      26: { name: keyword.control.callout.regexp }
-      27: { name: punctuation.definition.group.regexp }
+      18: { name: punctuation.definition.group.regexp }
+      19: { name: keyword.control.callout.regexp }
+      26: { name: variable.language.tag-name.regexp }
+      27: { name: keyword.control.callout.regexp }
+      28: { name: punctuation.definition.group.regexp }
 
   literals-regular-expression-literal-character-properties:
     name: constant.other.character-class.set.regexp

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -5351,7 +5351,7 @@
     | "(?&lt;name&gt;(?:[^"]|"")*)"
     | \^(?&lt;name&gt;(?:[^\^]|\^\^)*)\^
     | %(?&lt;name&gt;(?:[^%]|%%)*)%
-    | #(?&lt;name&gt;(?:[^#]|##)*)#
+    | \#(?&lt;name&gt;(?:[^#]|\#\#)*)\#
     | \$(?&lt;name&gt;(?:[^$]|\$\$)*)\$
     | \{(?&lt;name&gt;(?:[^}]|\}\})*)\}
   )?
@@ -5424,7 +5424,7 @@
           <key>11</key>
           <dict>
             <key>name</key>
-            <string>punctuation.definition.group.regexp</string>
+            <string>entity.name.function.callout.regexp</string>
           </dict>
           <key>12</key>
           <dict>
@@ -5434,22 +5434,22 @@
           <key>13</key>
           <dict>
             <key>name</key>
-            <string>keyword.control.callout.regexp</string>
+            <string>punctuation.definition.group.regexp</string>
           </dict>
           <key>14</key>
           <dict>
             <key>name</key>
-            <string>entity.name.function.callout.regexp</string>
+            <string>keyword.control.callout.regexp</string>
           </dict>
           <key>15</key>
           <dict>
             <key>name</key>
-            <string>variable.language.tag-name.regexp</string>
+            <string>entity.name.function.callout.regexp</string>
           </dict>
           <key>16</key>
           <dict>
             <key>name</key>
-            <string>punctuation.definition.group.regexp</string>
+            <string>variable.language.tag-name.regexp</string>
           </dict>
           <key>17</key>
           <dict>
@@ -5459,19 +5459,24 @@
           <key>18</key>
           <dict>
             <key>name</key>
-            <string>keyword.control.callout.regexp</string>
+            <string>punctuation.definition.group.regexp</string>
           </dict>
-          <key>25</key>
+          <key>19</key>
           <dict>
             <key>name</key>
-            <string>variable.language.tag-name.regexp</string>
+            <string>keyword.control.callout.regexp</string>
           </dict>
           <key>26</key>
           <dict>
             <key>name</key>
-            <string>keyword.control.callout.regexp</string>
+            <string>variable.language.tag-name.regexp</string>
           </dict>
           <key>27</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.callout.regexp</string>
+          </dict>
+          <key>28</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.group.regexp</string>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -639,6 +639,14 @@ let callouts = #/
   (?(?C9)(?=a)ab|de)  (?(?C%text%%abc%)(?!=d)ab|de)
   (*xyz) (*xyz[abc]) (*xyz[ab]{1,2}) (*xyz{1,2}) (*[ab]{1,2})
   (?{abc})
+  (?C`a``b`)
+  (?C'a''b')
+  (?C"a""b")
+  (?C^a^^b^)
+  (?C%a%%b%)
+  (?C#a##b#)
+  (?C$a$$b$)
+  (?C{a}}b})
   
   # https://github.com/kkos/oniguruma/blob/master/sample/callout.c
   ab(*bar{372,I am a bar's argument,あ})c(*FAIL)


### PR DESCRIPTION
This was being treated as a comment in the regular expression rather than a literal #.

cc @RedCMD

Fixes https://github.com/jtbandes/swift-tmlanguage/issues/1