### PR TITLE
Fix invalid.illegal `await try` matching even with no word boundary

### DIFF
--- a/Swift.tmLanguage.json
+++ b/Swift.tmLanguage.json
@@ -2051,7 +2051,7 @@
         },
 
         {
-          "match": "(?<!\\.)\\b(?:(await\\s+try)|(await)\\b)",
+          "match": "(?<!\\.)\\b(?:(await\\s+try)|(await))\\b",
           "captures": {
             "1": { "name": "invalid.illegal.try-must-precede-await.swift" },
             "2": { "name": "keyword.control.await.swift" }

--- a/Swift.tmLanguage.yaml
+++ b/Swift.tmLanguage.yaml
@@ -1658,7 +1658,7 @@ repository:
       - name: keyword.control.defer.swift
         match: (?<!\.)\bdefer\b
 
-      - match: (?<!\.)\b(?:(await\s+try)|(await)\b)
+      - match: (?<!\.)\b(?:(await\s+try)|(await))\b
         captures:
           1: { name: invalid.illegal.try-must-precede-await.swift }
           2: { name: keyword.control.await.swift }

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4566,7 +4566,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?&lt;!\.)\b(?:(await\s+try)|(await)\b)</string>
+            <string>(?&lt;!\.)\b(?:(await\s+try)|(await))\b</string>
             <key>captures</key>
             <dict>
               <key>1</key>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -284,6 +284,7 @@ func foo() async {
   let newURL = await server.redirectURL(for: url)
   let (data, response) = try await session.dataTask(with: newURL)
   let (data, response) = await try session.dataTask(with: newURL) // not allowed
+  let (data, response) = await tryFoo() // ok
   let (data, response) = await (try session.dataTask(with: newURL)) // ok
   async let dog = getDoggo()
   async let pup: Dog = getDoggo()


### PR DESCRIPTION
Fixes #5:

```swift
await tryFoo()
```