### PR TITLE
Remove conditionals and use recursion for regex InterpolatedCallout

### DIFF
--- a/Swift.tmLanguage.json
+++ b/Swift.tmLanguage.json
@@ -2298,7 +2298,7 @@
         {
           "comment": "Single-line regular expression literals must be matched all in one go\n in order to avoid ambiguities with operators, and to adhere to certain\n parsing rules in SE-0354/SE-0355, such as:\n - A regex literal will not be parsed if it contains an unbalanced ).\n - A regex may end with a space only if it began with an escaped space",
           "name": "string.regexp.line.swift",
-          "match": "(?x)\n(?!/\\s)         # non-extended regex literals may not start with a space or tab\n(?!//)          # disambiguation with line comments (redundant since comment rules occur earlier)\n(((\\#+)?)/)     # (1) for captures, (2) for matching end, (3) for conditionals\n(\\\\\\s)? # (4) may start with an escaped space or tab\n(?<guts>\n  (?>   # no backtracking, avoids issues with negative lookbehind at end\n    (?:\n      \\\\Q\n        (?:(?!\\\\E)(?!/\\2).)*+\n        (?:\\\\E\n          # A quoted sequence may not have a closing E, in which case it extends to the end of the regex\n          | (?(3)|(?<!\\s))(?=/\\2)\n        )\n      | \\\\.\n      | \\(\\?\\#[^)]*\\)\n      | \\(\\?\n          # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces\n          \\{(?<g1>\\{)?+(?<g2>\\{)?+(?<g3>\\{)?+(?<g4>\\{)?+(?<g5>\\{)?+\n          .+?\n          \\}(?(<g1>)\\})(?(<g2>)\\})(?(<g3>)\\})(?(<g4>)\\})(?(<g5>)\\})\n          (?:\\[(?!\\d)\\w+\\])?\n          [X<>]?\n        \\)\n      | (?<class>\\[ (?:\\\\. | [^\\[\\]] | \\g<class>)+ \\])\n      | \\(\\g<guts>?+\\)\n      | (?:(?!/\\2)[^()\\[\\\\])+  # any character (until end)\n    )+\n  )\n)?+\n# may end with a space only if it is an extended literal or contains only a single escaped space\n(?(3)|(?(5)(?<!\\s)))\n(/\\2)     # (12)\n| \\#+/.+(\\n)",
+          "match": "(?x)\n(?!/\\s)         # non-extended regex literals may not start with a space or tab\n(?!//)          # disambiguation with line comments (redundant since comment rules occur earlier)\n(((\\#+)?)/)     # (1) for captures, (2) for matching end, (3) for conditionals\n(\\\\\\s)? # (4) may start with an escaped space or tab\n(?<guts>\n  (?>   # no backtracking, avoids issues with negative lookbehind at end\n    (?:\n      \\\\Q\n        (?:(?!\\\\E)(?!/\\2).)*+\n        (?:\\\\E\n          # A quoted sequence may not have a closing E, in which case it extends to the end of the regex\n          | (?(3)|(?<!\\s))(?=/\\2)\n        )\n      | \\\\.\n      | \\(\\?\\#[^)]*\\)\n      | \\(\\?\n          # InterpolatedCallout\n          (?>(\\{(?:\\g<-1>|(?!{).*?)\\}))\n          (?:\\[(?!\\d)\\w+\\])?\n          [X<>]?\n        \\)\n      | (?<class>\\[ (?:\\\\. | [^\\[\\]] | \\g<class>)+ \\])\n      | \\(\\g<guts>?+\\)\n      | (?:(?!/\\2)[^()\\[\\\\])+  # any character (until end)\n    )+\n  )\n)?+\n# may end with a space only if it is an extended literal or contains only a single escaped space\n(?(3)|(?(5)(?<!\\s)))\n(/\\2)     # (12)\n| \\#+/.+(\\n)",
           "captures": {
             "0": {
               "patterns": [
@@ -2310,8 +2310,8 @@
             "1": {
               "name": "punctuation.definition.string.begin.regexp.swift"
             },
-            "12": { "name": "punctuation.definition.string.end.regexp.swift" },
-            "13": { "name": "invalid.illegal.returns-not-allowed.regexp" }
+            "8": { "name": "punctuation.definition.string.end.regexp.swift" },
+            "9": { "name": "invalid.illegal.returns-not-allowed.regexp" }
           }
         }
       ]
@@ -2426,7 +2426,7 @@
 
     "literals-regular-expression-literal-callout": {
       "name": "meta.callout.regexp",
-      "match": "(?x)\n# PCRECallout\n(\\()(?<keyw>\\?C)\n  (?:\n    (?<num>\\d+)\n    | `(?<name>(?:[^`]|``)*)`\n    | '(?<name>(?:[^']|'')*)'\n    | \"(?<name>(?:[^\"]|\"\")*)\"\n    | \\^(?<name>(?:[^\\^]|\\^\\^)*)\\^\n    | %(?<name>(?:[^%]|%%)*)%\n    | \\#(?<name>(?:[^#]|\\#\\#)*)\\#\n    | \\$(?<name>(?:[^$]|\\$\\$)*)\\$\n    | \\{(?<name>(?:[^}]|\\}\\})*)\\}\n  )?\n(\\))\n# NamedCallout\n| (\\()(?<keyw>\\*)\n    (?<name>(?!\\d)\\w+)\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?:\\{ [^,}]+ (?:,[^,}]+)* \\})?\n  (\\))\n# InterpolatedCallout\n| (\\()(?<keyw>\\?)\n    # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces\n    (\\{(?<g1>\\{)?+(?<g2>\\{)?+(?<g3>\\{)?+(?<g4>\\{)?+(?<g5>\\{)?+) .+? \\}(?(<g1>)\\})(?(<g2>)\\})(?(<g3>)\\})(?(<g4>)\\})(?(<g5>)\\})\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?<keyw>[X<>]?)\n  (\\))",
+      "match": "(?x)\n# PCRECallout\n(\\()(?<keyw>\\?C)\n  (?:\n    (?<num>\\d+)\n    | `(?<name>(?:[^`]|``)*)`\n    | '(?<name>(?:[^']|'')*)'\n    | \"(?<name>(?:[^\"]|\"\")*)\"\n    | \\^(?<name>(?:[^\\^]|\\^\\^)*)\\^\n    | %(?<name>(?:[^%]|%%)*)%\n    | \\#(?<name>(?:[^#]|\\#\\#)*)\\#\n    | \\$(?<name>(?:[^$]|\\$\\$)*)\\$\n    | \\{(?<name>(?:[^}]|\\}\\})*)\\}\n  )?\n(\\))\n# NamedCallout\n| (\\()(?<keyw>\\*)\n    (?<name>(?!\\d)\\w+)\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?:\\{ [^,}]+ (?:,[^,}]+)* \\})?\n  (\\))\n# InterpolatedCallout\n| (\\()(?<keyw>\\?)\n    (?>(\\{(?:\\g<-1>|(?!{).*?)\\}))\n    (?:\\[(?<tag>(?!\\d)\\w+)\\])?\n    (?<keyw>[X<>]?)\n  (\\))",
       "captures": {
         "1": { "name": "punctuation.definition.group.regexp" },
         "2": { "name": "keyword.control.callout.regexp" },
@@ -2447,9 +2447,9 @@
         "17": { "name": "punctuation.definition.group.regexp" },
         "18": { "name": "punctuation.definition.group.regexp" },
         "19": { "name": "keyword.control.callout.regexp" },
-        "26": { "name": "variable.language.tag-name.regexp" },
-        "27": { "name": "keyword.control.callout.regexp" },
-        "28": { "name": "punctuation.definition.group.regexp" }
+        "21": { "name": "variable.language.tag-name.regexp" },
+        "22": { "name": "keyword.control.callout.regexp" },
+        "23": { "name": "punctuation.definition.group.regexp" }
       }
     },
 

--- a/Swift.tmLanguage.yaml
+++ b/Swift.tmLanguage.yaml
@@ -1840,10 +1840,8 @@ repository:
                 | \\.
                 | \(\?\#[^)]*\)
                 | \(\?
-                    # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces
-                    \{(?<g1>\{)?+(?<g2>\{)?+(?<g3>\{)?+(?<g4>\{)?+(?<g5>\{)?+
-                    .+?
-                    \}(?(<g1>)\})(?(<g2>)\})(?(<g3>)\})(?(<g4>)\})(?(<g5>)\})
+                    # InterpolatedCallout
+                    (?>(\{(?:\g<-1>|(?!{).*?)\}))
                     (?:\[(?!\d)\w+\])?
                     [X<>]?
                   \)
@@ -1862,8 +1860,8 @@ repository:
             patterns:
               - include: "#literals-regular-expression-literal-regex-guts"
           1: { name: punctuation.definition.string.begin.regexp.swift }
-          12: { name: punctuation.definition.string.end.regexp.swift }
-          13: { name: invalid.illegal.returns-not-allowed.regexp }
+          8: { name: punctuation.definition.string.end.regexp.swift }
+          9: { name: invalid.illegal.returns-not-allowed.regexp }
 
   literals-regular-expression-literal-backreference-or-subpattern:
     # These patterns are separated to work around issues like https://github.com/microsoft/vscode-textmate/issues/164
@@ -1990,8 +1988,7 @@ repository:
         (\))
       # InterpolatedCallout
       | (\()(?<keyw>\?)
-          # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces
-          (\{(?<g1>\{)?+(?<g2>\{)?+(?<g3>\{)?+(?<g4>\{)?+(?<g5>\{)?+) .+? \}(?(<g1>)\})(?(<g2>)\})(?(<g3>)\})(?(<g4>)\})(?(<g5>)\})
+          (?>(\{(?:\g<-1>|(?!{).*?)\}))
           (?:\[(?<tag>(?!\d)\w+)\])?
           (?<keyw>[X<>]?)
         (\))
@@ -2015,9 +2012,9 @@ repository:
       17: { name: punctuation.definition.group.regexp }
       18: { name: punctuation.definition.group.regexp }
       19: { name: keyword.control.callout.regexp }
-      26: { name: variable.language.tag-name.regexp }
-      27: { name: keyword.control.callout.regexp }
-      28: { name: punctuation.definition.group.regexp }
+      21: { name: variable.language.tag-name.regexp }
+      22: { name: keyword.control.callout.regexp }
+      23: { name: punctuation.definition.group.regexp }
 
   literals-regular-expression-literal-character-properties:
     name: constant.other.character-class.set.regexp

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4969,10 +4969,8 @@
       | \\.
       | \(\?\#[^)]*\)
       | \(\?
-          # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces
-          \{(?&lt;g1&gt;\{)?+(?&lt;g2&gt;\{)?+(?&lt;g3&gt;\{)?+(?&lt;g4&gt;\{)?+(?&lt;g5&gt;\{)?+
-          .+?
-          \}(?(&lt;g1&gt;)\})(?(&lt;g2&gt;)\})(?(&lt;g3&gt;)\})(?(&lt;g4&gt;)\})(?(&lt;g5&gt;)\})
+          # InterpolatedCallout
+          (?&gt;(\{(?:\g&lt;-1&gt;|(?!{).*?)\}))
           (?:\[(?!\d)\w+\])?
           [X&lt;&gt;]?
         \)
@@ -5003,12 +5001,12 @@
                 <key>name</key>
                 <string>punctuation.definition.string.begin.regexp.swift</string>
               </dict>
-              <key>12</key>
+              <key>8</key>
               <dict>
                 <key>name</key>
                 <string>punctuation.definition.string.end.regexp.swift</string>
               </dict>
-              <key>13</key>
+              <key>9</key>
               <dict>
                 <key>name</key>
                 <string>invalid.illegal.returns-not-allowed.regexp</string>
@@ -5364,8 +5362,7 @@
   (\))
 # InterpolatedCallout
 | (\()(?&lt;keyw&gt;\?)
-    # we only support a fixed maximum number of braces because otherwise we can't balance the number of open and close braces
-    (\{(?&lt;g1&gt;\{)?+(?&lt;g2&gt;\{)?+(?&lt;g3&gt;\{)?+(?&lt;g4&gt;\{)?+(?&lt;g5&gt;\{)?+) .+? \}(?(&lt;g1&gt;)\})(?(&lt;g2&gt;)\})(?(&lt;g3&gt;)\})(?(&lt;g4&gt;)\})(?(&lt;g5&gt;)\})
+    (?&gt;(\{(?:\g&lt;-1&gt;|(?!{).*?)\}))
     (?:\[(?&lt;tag&gt;(?!\d)\w+)\])?
     (?&lt;keyw&gt;[X&lt;&gt;]?)
   (\))</string>
@@ -5466,17 +5463,17 @@
             <key>name</key>
             <string>keyword.control.callout.regexp</string>
           </dict>
-          <key>26</key>
+          <key>21</key>
           <dict>
             <key>name</key>
             <string>variable.language.tag-name.regexp</string>
           </dict>
-          <key>27</key>
+          <key>22</key>
           <dict>
             <key>name</key>
             <string>keyword.control.callout.regexp</string>
           </dict>
-          <key>28</key>
+          <key>23</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.group.regexp</string>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -650,6 +650,13 @@ let callouts = #/
   (?C$a$$b$)
   (?C{a}}b})
   
+  (?{ab}X)
+  (?{ab { c}X)
+  (?{abc } c}X) # invalid
+  (?{{abc { c}}X)
+  (?{{abc } c}}X)
+  (?{{abc }) c}}X)
+  
   # https://github.com/kkos/oniguruma/blob/master/sample/callout.c
   ab(*bar{372,I am a bar's argument,あ})c(*FAIL)
   (?{{!{}#$%&'()=-~^|[_]`@*:+;<>?/.\\,}}[symbols])c
@@ -663,6 +670,13 @@ let callouts = #/
   (?~|absent)
   (?~|)
 /#
+let callout = /(?{a/b}X)/
+let callout = /(?{a/b}X)/
+let callout = /(?{ab/ { c}X)/
+let callout = /(?{abc/ } c}X)/ # invalid
+let callout = /(?{{abc/ { c}}X)/
+let callout = /(?{{abc/ } c}}X)/
+let callout = /(?{{abc/ }) c}}X)/
 
 let comments = #/
   not a comment

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -679,10 +679,13 @@ let callouts = #/
 let callout = /(?{a/b}X)/
 let callout = /(?{a/b}X)/
 let callout = /(?{ab/ { c}X)/
-let callout = /(?{abc/ } c}X)/ # invalid
-let callout = /(?{{abc/ { c}}X)/
-let callout = /(?{{abc/ } c}}X)/
-let callout = /(?{{abc/ }) c}}X)/
+let callout = /(?{abc/ } d}X)/ //invalid
+let callout = /(?{{abc/ }}}X)/ //invalid
+let callout = /(?{{abc/ }}}}X)/ //invalid
+let callout = /(?{{abc/ }} d}}X)/ //invalid
+let callout = /(?{{abc/ { d}}X)/
+let callout = /(?{{abc/ } d}}X)/
+let callout = /(?{{abc/ }) d}}X)/
 
 let comments = #/
   not a comment


### PR DESCRIPTION
More work towards #16

If we wanted to capture the `{` `}` delimiters with some scopes, I think we might run into https://github.com/microsoft/vscode-textmate/issues/164 & related issues. But for now we aren't highlighting them so it's fine.