### PR TITLE
Add some tests for interpolated callouts

### DIFF
--- a/test/assert-scopes.test.ts
+++ b/test/assert-scopes.test.ts
@@ -40,6 +40,23 @@ await test("assertions", () => {
     _`    ~~~ example.bar`,
   );
 
+  assertScopes(
+    //
+    $`foo baz`,
+    _.none("example.bar"),
+  );
+
+  assert.throws(
+    () => {
+      assertScopes(
+        //
+        $`foo bar`,
+        _.none("example.foo"),
+      );
+    },
+    { message: "Unexpected scope example.foo (0-3: source.test, example.foo)" },
+  );
+
   assert.throws(
     () => {
       assertScopes(

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -684,4 +684,62 @@ await suite("regex literals", async () => {
       _`~~ string.regexp.block.swift`,
     );
   });
+
+  // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0355-regex-syntax-run-time-construction.md#callouts
+  await test("interpolated callouts in single-line literals", () => {
+    assertScopes(
+      $`/(?{a/b}X)/`,
+      _`~~~~~~~~~~~ string.regexp.line.swift`,
+      _` ~~~~~~~~~  meta.callout.regexp`,
+      _` ~          punctuation.definition.group.regexp`,
+      _`  ~         keyword.control.callout.regexp`,
+      _`        ~   keyword.control.callout.regexp`,
+      _`         ~  punctuation.definition.group.regexp`,
+
+      $`#/(?{a/b}X)/#`,
+      _`~~~~~~~~~~~~~ string.regexp.line.swift`,
+      _`  ~~~~~~~~~   meta.callout.regexp`,
+      _`  ~           punctuation.definition.group.regexp`,
+      _`   ~          keyword.control.callout.regexp`,
+      _`         ~    keyword.control.callout.regexp`,
+      _`          ~   punctuation.definition.group.regexp`,
+
+      $`/(?{ab/ { c}X)/`,
+      _`~~~~~~~~~~~~~~~ string.regexp.line.swift`,
+      _` ~~~~~~~~~~~~~  meta.callout.regexp`,
+      _` ~              punctuation.definition.group.regexp`,
+      _`  ~             keyword.control.callout.regexp`,
+      _`            ~   keyword.control.callout.regexp`,
+      _`             ~  punctuation.definition.group.regexp`,
+      $`/(?{abc/ } d}X)/ //invalid`,
+      _.none("string.regexp.line.swift"),
+      $`/(?{{abc/ }}}X)/ //invalid`,
+      _.none("string.regexp.line.swift"),
+      $`/(?{{abc/ }}}}X)/ //invalid`,
+      _.none("string.regexp.line.swift"),
+      $`/(?{{abc/ }} d}}X)/ //invalid`,
+      _.none("string.regexp.line.swift"),
+      $`/(?{{abc/ { d}}X)/`,
+      _`~~~~~~~~~~~~~~~~~~ string.regexp.line.swift`,
+      _` ~~~~~~~~~~~~~~~~  meta.callout.regexp`,
+      _` ~                 punctuation.definition.group.regexp`,
+      _`  ~                keyword.control.callout.regexp`,
+      _`               ~   keyword.control.callout.regexp`,
+      _`                ~  punctuation.definition.group.regexp`,
+      $`/(?{{abc/ } d}}X)/`,
+      _`~~~~~~~~~~~~~~~~~~ string.regexp.line.swift`,
+      _` ~~~~~~~~~~~~~~~~  meta.callout.regexp`,
+      _` ~                 punctuation.definition.group.regexp`,
+      _`  ~                keyword.control.callout.regexp`,
+      _`               ~   keyword.control.callout.regexp`,
+      _`                ~  punctuation.definition.group.regexp`,
+      $`/(?{{abc/ }) d}}X)/`,
+      _`~~~~~~~~~~~~~~~~~~~ string.regexp.line.swift`,
+      _` ~~~~~~~~~~~~~~~~~  meta.callout.regexp`,
+      _` ~                  punctuation.definition.group.regexp`,
+      _`  ~                 keyword.control.callout.regexp`,
+      _`                ~   keyword.control.callout.regexp`,
+      _`                 ~  punctuation.definition.group.regexp`,
+    );
+  });
 });

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -711,14 +711,19 @@ await suite("regex literals", async () => {
       _`  ~             keyword.control.callout.regexp`,
       _`            ~   keyword.control.callout.regexp`,
       _`             ~  punctuation.definition.group.regexp`,
+
       $`/(?{abc/ } d}X)/ //invalid`,
       _.none("string.regexp.line.swift"),
+
       $`/(?{{abc/ }}}X)/ //invalid`,
       _.none("string.regexp.line.swift"),
+
       $`/(?{{abc/ }}}}X)/ //invalid`,
       _.none("string.regexp.line.swift"),
+
       $`/(?{{abc/ }} d}}X)/ //invalid`,
       _.none("string.regexp.line.swift"),
+
       $`/(?{{abc/ { d}}X)/`,
       _`~~~~~~~~~~~~~~~~~~ string.regexp.line.swift`,
       _` ~~~~~~~~~~~~~~~~  meta.callout.regexp`,
@@ -726,6 +731,7 @@ await suite("regex literals", async () => {
       _`  ~                keyword.control.callout.regexp`,
       _`               ~   keyword.control.callout.regexp`,
       _`                ~  punctuation.definition.group.regexp`,
+
       $`/(?{{abc/ } d}}X)/`,
       _`~~~~~~~~~~~~~~~~~~ string.regexp.line.swift`,
       _` ~~~~~~~~~~~~~~~~  meta.callout.regexp`,
@@ -733,6 +739,7 @@ await suite("regex literals", async () => {
       _`  ~                keyword.control.callout.regexp`,
       _`               ~   keyword.control.callout.regexp`,
       _`                ~  punctuation.definition.group.regexp`,
+
       $`/(?{{abc/ }) d}}X)/`,
       _`~~~~~~~~~~~~~~~~~~~ string.regexp.line.swift`,
       _` ~~~~~~~~~~~~~~~~~  meta.callout.regexp`,


### PR DESCRIPTION
- Add `_.none` to assert a scope is not matched
- Add some assertions for interpolated callout nesting (relates to #16)