### PR TITLE
Remove single-line recursion for interpolated callouts

### DIFF
--- a/Swift.tmLanguage.json
+++ b/Swift.tmLanguage.json
@@ -2298,7 +2298,7 @@
         {
           "comment": "Single-line regular expression literals must be matched all in one go\n in order to avoid ambiguities with operators, and to adhere to certain\n parsing rules in SE-0354/SE-0355, such as:\n - A regex literal will not be parsed if it contains an unbalanced ).\n - A regex may end with a space only if it began with an escaped space",
           "name": "string.regexp.line.swift",
-          "match": "(?x)\n(/)\n(?!\\s)         # non-extended regex literals may not start with a space or tab\n(?!/)          # disambiguation with line comments (redundant since comment rules occur earlier)\n(?:\n  \\\\\\s(?=/)    # may end with a space only if it contains only a single escaped space, i.e. /\\ /\n  | (?<guts>\n    (?>   # no backtracking, avoids issues with negative lookbehind at end\n      (?:\n        \\\\Q\n          (?:(?!\\\\E)(?!/).)*+\n          # A quoted sequence may not have a closing E, in which case it extends to the end of the regex\n          (?:\\\\E | (?=/))\n        | \\\\.\n        | \\(\\?\\#[^)]*\\)\n        | \\(\\?\n            # InterpolatedCallout\n            (?>(\\{(?:\\g<-1>|(?!{).*?)\\}))\n            (?:\\[(?!\\d)\\w+\\])?\n            [X<>]?\n          \\)\n        | (?<class>\\[ (?:\\\\. | [^\\[\\]] | \\g<class>)+ \\])\n        | \\(\\g<guts>?+\\)\n        | (?:(?!/)[^()\\[\\\\])+  # any character (until end)\n      )+\n    )\n  )?+\n  (?<!\\s)\n)\n(/)",
+          "match": "(?x)\n(/)\n(?!\\s)         # non-extended regex literals may not start with a space or tab\n(?!/)          # disambiguation with line comments (redundant since comment rules occur earlier)\n(?:\n  \\\\\\s(?=/)    # may end with a space only if it contains only a single escaped space, i.e. /\\ /\n  | (?<guts>\n    (?>   # no backtracking, avoids issues with negative lookbehind at end\n      (?:\n        \\\\Q\n          (?:(?!\\\\E)(?!/).)*+\n          # A quoted sequence may not have a closing E, in which case it extends to the end of the regex\n          (?:\\\\E | (?=/))\n        | \\\\.\n        | \\(\\?\\#[^)]*\\)\n        | \\(\\?\n            # InterpolatedCallout\n            (?>\n              {[^{].*?}\n              | {{[^{].*?}}\n              | {{{[^{].*?}}}\n              | {{{{[^{].*?}}}}\n              | {{{{{[^{].*?}}}}}\n              | {{{{{{.+?}}}}}}\n            )\n            (?:\\[(?!\\d)\\w+\\])?\n            [X<>]?\n          \\)\n        | (?<class>\\[ (?:\\\\. | [^\\[\\]] | \\g<class>)+ \\])\n        | \\(\\g<guts>?+\\)\n        | (?:(?!/)[^()\\[\\\\])+  # any character (until end)\n      )+\n    )\n  )?+\n  (?<!\\s)\n)\n(/)",
           "captures": {
             "0": {
               "patterns": [
@@ -2316,7 +2316,7 @@
 
         {
           "name": "string.regexp.line.extended.swift",
-          "match": "(?x)\n((\\#+)/)     # (1) for captures, (2) for matching end\n(?<guts>\n  (?>   # no backtracking, avoids issues with negative lookbehind at end\n    (?:\n      \\\\Q\n        (?:(?!\\\\E)(?!/\\2).)*+\n        # A quoted sequence may not have a closing E, in which case it extends to the end of the regex\n        (?:\\\\E | (?=/\\2))\n      | \\\\.\n      | \\(\\?\\#[^)]*\\)\n      | \\(\\?\n          # InterpolatedCallout\n          (?>(\\{(?:\\g<-1>|(?!{).*?)\\}))\n          (?:\\[(?!\\d)\\w+\\])?\n          [X<>]?\n        \\)\n      | (?<class>\\[ (?:\\\\. | [^\\[\\]] | \\g<class>)+ \\])\n      | \\(\\g<guts>?+\\)\n      | (?:(?!/\\2)[^()\\[\\\\])+  # any character (until end)\n    )+\n  )\n)?+\n(/\\2)     # (6)\n| \\#+/.+(\\n)",
+          "match": "(?x)\n((\\#+)/)     # (1) for captures, (2) for matching end\n(?<guts>\n  (?>   # no backtracking, avoids issues with negative lookbehind at end\n    (?:\n      \\\\Q\n        (?:(?!\\\\E)(?!/\\2).)*+\n        # A quoted sequence may not have a closing E, in which case it extends to the end of the regex\n        (?:\\\\E | (?=/\\2))\n      | \\\\.\n      | \\(\\?\\#[^)]*\\)\n      | \\(\\?\n          # InterpolatedCallout\n          (?>\n            {[^{].*?}\n            | {{[^{].*?}}\n            | {{{[^{].*?}}}\n            | {{{{[^{].*?}}}}\n            | {{{{{[^{].*?}}}}}\n            | {{{{{{.+?}}}}}}\n          )\n          (?:\\[(?!\\d)\\w+\\])?\n          [X<>]?\n        \\)\n      | (?<class>\\[ (?:\\\\. | [^\\[\\]] | \\g<class>)+ \\])\n      | \\(\\g<guts>?+\\)\n      | (?:(?!/\\2)[^()\\[\\\\])+  # any character (until end)\n    )+\n  )\n)?+\n(/\\2)     # (6)\n| \\#+/.+(\\n)",
           "captures": {
             "0": {
               "patterns": [
@@ -2328,8 +2328,8 @@
             "1": {
               "name": "punctuation.definition.string.begin.regexp.swift"
             },
-            "6": { "name": "punctuation.definition.string.end.regexp.swift" },
-            "7": { "name": "invalid.illegal.returns-not-allowed.regexp" }
+            "5": { "name": "punctuation.definition.string.end.regexp.swift" },
+            "6": { "name": "invalid.illegal.returns-not-allowed.regexp" }
           }
         }
       ]

--- a/Swift.tmLanguage.yaml
+++ b/Swift.tmLanguage.yaml
@@ -1840,7 +1840,14 @@ repository:
                   | \(\?\#[^)]*\)
                   | \(\?
                       # InterpolatedCallout
-                      (?>(\{(?:\g<-1>|(?!{).*?)\}))
+                      (?>
+                        {[^{].*?}
+                        | {{[^{].*?}}
+                        | {{{[^{].*?}}}
+                        | {{{{[^{].*?}}}}
+                        | {{{{{[^{].*?}}}}}
+                        | {{{{{{.+?}}}}}}
+                      )
                       (?:\[(?!\d)\w+\])?
                       [X<>]?
                     \)
@@ -1875,7 +1882,14 @@ repository:
                 | \(\?\#[^)]*\)
                 | \(\?
                     # InterpolatedCallout
-                    (?>(\{(?:\g<-1>|(?!{).*?)\}))
+                    (?>
+                      {[^{].*?}
+                      | {{[^{].*?}}
+                      | {{{[^{].*?}}}
+                      | {{{{[^{].*?}}}}
+                      | {{{{{[^{].*?}}}}}
+                      | {{{{{{.+?}}}}}}
+                    )
                     (?:\[(?!\d)\w+\])?
                     [X<>]?
                   \)
@@ -1892,8 +1906,8 @@ repository:
             patterns:
               - include: "#literals-regular-expression-literal-regex-guts"
           1: { name: punctuation.definition.string.begin.regexp.swift }
-          6: { name: punctuation.definition.string.end.regexp.swift }
-          7: { name: invalid.illegal.returns-not-allowed.regexp }
+          5: { name: punctuation.definition.string.end.regexp.swift }
+          6: { name: invalid.illegal.returns-not-allowed.regexp }
 
   literals-regular-expression-literal-backreference-or-subpattern:
     # These patterns are separated to work around issues like https://github.com/microsoft/vscode-textmate/issues/164

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4969,7 +4969,14 @@
         | \(\?\#[^)]*\)
         | \(\?
             # InterpolatedCallout
-            (?&gt;(\{(?:\g&lt;-1&gt;|(?!{).*?)\}))
+            (?&gt;
+              {[^{].*?}
+              | {{[^{].*?}}
+              | {{{[^{].*?}}}
+              | {{{{[^{].*?}}}}
+              | {{{{{[^{].*?}}}}}
+              | {{{{{{.+?}}}}}}
+            )
             (?:\[(?!\d)\w+\])?
             [X&lt;&gt;]?
           \)
@@ -5023,7 +5030,14 @@
       | \(\?\#[^)]*\)
       | \(\?
           # InterpolatedCallout
-          (?&gt;(\{(?:\g&lt;-1&gt;|(?!{).*?)\}))
+          (?&gt;
+            {[^{].*?}
+            | {{[^{].*?}}
+            | {{{[^{].*?}}}
+            | {{{{[^{].*?}}}}
+            | {{{{{[^{].*?}}}}}
+            | {{{{{{.+?}}}}}}
+          )
           (?:\[(?!\d)\w+\])?
           [X&lt;&gt;]?
         \)
@@ -5052,12 +5066,12 @@
                 <key>name</key>
                 <string>punctuation.definition.string.begin.regexp.swift</string>
               </dict>
-              <key>6</key>
+              <key>5</key>
               <dict>
                 <key>name</key>
                 <string>punctuation.definition.string.end.regexp.swift</string>
               </dict>
-              <key>7</key>
+              <key>6</key>
               <dict>
                 <key>name</key>
                 <string>invalid.illegal.returns-not-allowed.regexp</string>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -687,6 +687,25 @@ let callout = /(?{{abc/ }} d}}X)/ //invalid
 let callout = /(?{{abc/ { d}}X)/
 let callout = /(?{{abc/ } d}}X)/
 let callout = /(?{{abc/ }) d}}X)/
+let callout = #/ (?{a}X) /#
+let callout = #/ (?{{a}}X) /#
+let callout = #/ (?{a{b}X) /#
+let callout = #/ (?{{a}b}}X) /#
+let callout = #/ (?{a}}X) /#
+let callout = #/ (?{a}b}X) /#
+let callout = #/ (?{{a}}}X) /#
+let callout = #/ (?{{a}}}}X) /#
+let callout = #/ (?{{a}}b}}X) /#
+let callout = #/ (?{{{{a}}}b/#}}}}X) /#
+let callout = #/ (?{{{{a}}}}b/#}}}}X) /#
+let callout = #/ (?{{{{{a}}}}b/#}}}}}X) /#
+let callout = #/ (?{{{{{a}}}}}b/#}}}}}X) /#
+let callout = #/ (?{{{{{{a}}}}}b/#}}}}}}X) /#
+let callout = #/ (?{{{{{{a}}}}}}b/#}}}}}}X) /#
+let callout = #/ (?{{{{{{{a}}}}}}b/#}}}}}}}X) /#
+let callout = #/ (?{{{{{{{a}}}}}}}b/#}}}}}}}X) /#
+let callout = #/ (?{{{{{{{{a}}}}}}}b/#}}}}}}}}X) /#
+let callout = #/ (?{{{{{{{{a}}}}}}}}b/#}}}}}}}}X) /#
 
 let comments = #/
   not a comment

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -701,13 +701,14 @@ await suite("regex literals", async () => {
   // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0355-regex-syntax-run-time-construction.md#callouts
   await test("interpolated callouts in single-line literals", () => {
     assertScopes(
-      $`/(?{a/b}X)/`,
-      _`~~~~~~~~~~~ string.regexp.line.swift`,
-      _` ~~~~~~~~~  meta.callout.regexp`,
-      _` ~          punctuation.definition.group.regexp`,
-      _`  ~         keyword.control.callout.regexp`,
-      _`        ~   keyword.control.callout.regexp`,
-      _`         ~  punctuation.definition.group.regexp`,
+      $`/(?{a/b}[tag]X)/`,
+      _`~~~~~~~~~~~~~~~~ string.regexp.line.swift`,
+      _` ~~~~~~~~~~~~~~  meta.callout.regexp`,
+      _` ~               punctuation.definition.group.regexp`,
+      _`  ~              keyword.control.callout.regexp`,
+      _`         ~~~     variable.language.tag-name.regexp`,
+      _`             ~   keyword.control.callout.regexp`,
+      _`              ~  punctuation.definition.group.regexp`,
 
       $`#/(?{a/b}X)/#`,
       _`~~~~~~~~~~~~~ string.regexp.line.extended.swift`,
@@ -760,6 +761,49 @@ await suite("regex literals", async () => {
       _`  ~                 keyword.control.callout.regexp`,
       _`                ~   keyword.control.callout.regexp`,
       _`                 ~  punctuation.definition.group.regexp`,
+    );
+
+    assertScopes(
+      $`#/ (?{a}) /#`,
+      _`~~~~~~~~~~~~ string.regexp.line.extended.swift`,
+      _`   ~~~~~~    meta.callout.regexp`,
+      _`   ~         punctuation.definition.group.regexp`,
+      _`    ~        keyword.control.callout.regexp`,
+      _`        ~    punctuation.definition.group.regexp`,
+
+      $`#/ (?{{a}}) /#`,
+      _`~~~~~~~~~~~~~~ string.regexp.line.extended.swift`,
+      _`   ~~~~~~~~    meta.callout.regexp`,
+      _`   ~           punctuation.definition.group.regexp`,
+      _`    ~          keyword.control.callout.regexp`,
+      _`          ~    punctuation.definition.group.regexp`,
+
+      $`#/ (?{a{b}) /#`,
+      _`~~~~~~~~~~~~~~ string.regexp.line.extended.swift`,
+      _`   ~~~~~~~~    meta.callout.regexp`,
+      _`   ~           punctuation.definition.group.regexp`,
+      _`    ~          keyword.control.callout.regexp`,
+      _`          ~    punctuation.definition.group.regexp`,
+
+      $`#/ (?{{a}b}}) /#`,
+      _`~~~~~~~~~~~~~~~~ string.regexp.line.extended.swift`,
+      _`   ~~~~~~~~~~    meta.callout.regexp`,
+      _`   ~             punctuation.definition.group.regexp`,
+      _`    ~            keyword.control.callout.regexp`,
+      _`            ~    punctuation.definition.group.regexp`,
+    );
+
+    assertScopes(
+      $`#/ (?{a}}) /#`,
+      _.none("meta.callout.regexp"),
+      $`#/ (?{a}b}) /#`,
+      _.none("meta.callout.regexp"),
+      $`#/ (?{{a}}}) /#`,
+      _.none("meta.callout.regexp"),
+      $`#/ (?{{a}}}}) /#`,
+      _.none("meta.callout.regexp"),
+      $`#/ (?{{a}}b}}) /#`,
+      _.none("meta.callout.regexp"),
     );
   });
 });


### PR DESCRIPTION
Using the suggestion from https://github.com/jtbandes/swift-tmlanguage/issues/16#issuecomment-2600116970.

Not all cases are covered by unit tests but the results look visually alright and these are quite rare edge cases anyway. Plus, true recursion is still used in the `literals-regular-expression-literal-callout` rules which are used once the whole regex literal has been matched.