### PR TITLE
Add support for `nonisolated(unsafe)` (SE-0461) and other concurrency features

### DIFF
--- a/Swift.tmLanguage.json
+++ b/Swift.tmLanguage.json
@@ -269,6 +269,11 @@
     "builtin-types-builtin-protocol-type": {
       "patterns": [
         {
+          "name": "support.type.swift",
+          "match": "\\bActor\\b"
+        },
+
+        {
           "comment": "Protocols in the standard library in Swift 3",
           "name": "support.type.swift",
           "match": "\\b(?:Ra(?:n(?:domAccess(?:Collection|Indexable)|geReplaceable(?:Collection|Indexable))|wRepresentable)|M(?:irrorPath|utable(?:Collection|Indexable))|Bi(?:naryFloatingPoint|twiseOperations|directional(?:Collection|Indexable))|S(?:tr(?:ideable|eamable)|igned(?:Number|Integer)|e(?:tAlgebra|quence))|Hashable|C(?:o(?:llection|mparable)|ustom(?:Reflectable|StringConvertible|DebugStringConvertible|PlaygroundQuickLookable|LeafReflectable)|VarArg)|TextOutputStream|I(?:n(?:teger(?:Arithmetic)?|dexable(?:Base)?)|teratorProtocol)|OptionSet|Un(?:signedInteger|icodeCodec)|E(?:quatable|rror|xpressibleBy(?:BooleanLiteral|String(?:Interpolation|Literal)|NilLiteral|IntegerLiteral|DictionaryLiteral|UnicodeScalarLiteral|ExtendedGraphemeClusterLiteral|FloatLiteral|ArrayLiteral))|FloatingPoint|L(?:osslessStringConvertible|azy(?:SequenceProtocol|CollectionProtocol))|A(?:nyObject|bsoluteValuable))\\b"
@@ -674,6 +679,11 @@
         {
           "name": "storage.modifier.swift",
           "match": "\\b(?:inout|isolated|borrowing|consuming)\\b"
+        },
+
+        {
+          "name": "storage.modifier.swift",
+          "match": "\\bnonisolated(?:\\(nonsending\\)|\\b)"
         },
 
         {
@@ -2154,7 +2164,12 @@
 
         {
           "name": "storage.modifier.swift",
-          "match": "(?<!\\.)\\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience|infix|prefix|postfix|distributed|nonisolated|borrowing|consuming)\\b"
+          "match": "(?<!\\.)\\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience|infix|prefix|postfix|distributed|borrowing|consuming)\\b"
+        },
+
+        {
+          "name": "storage.modifier.swift",
+          "match": "(?<!\\.)\\bnonisolated(?:\\(nonsending\\)|\\b)"
         },
 
         {
@@ -2188,7 +2203,7 @@
 
         {
           "name": "support.variable.swift",
-          "match": "\\B(?:#file|#filePath|#fileID|#line|#column|#function|#dsohandle)\\b|\\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\\b"
+          "match": "\\B(?:#file|#filePath|#fileID|#line|#column|#function|#dsohandle|#isolation)\\b|\\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\\b"
         },
 
         {

--- a/Swift.tmLanguage.yaml
+++ b/Swift.tmLanguage.yaml
@@ -187,6 +187,9 @@ repository:
 
   builtin-types-builtin-protocol-type:
     patterns:
+      - name: support.type.swift
+        match: \bActor\b
+
       # Protocols in the standard library in Swift 3
       - name: support.type.swift
         match: \b(?:Ra(?:n(?:domAccess(?:Collection|Indexable)|geReplaceable(?:Collection|Indexable))|wRepresentable)|M(?:irrorPath|utable(?:Collection|Indexable))|Bi(?:naryFloatingPoint|twiseOperations|directional(?:Collection|Indexable))|S(?:tr(?:ideable|eamable)|igned(?:Number|Integer)|e(?:tAlgebra|quence))|Hashable|C(?:o(?:llection|mparable)|ustom(?:Reflectable|StringConvertible|DebugStringConvertible|PlaygroundQuickLookable|LeafReflectable)|VarArg)|TextOutputStream|I(?:n(?:teger(?:Arithmetic)?|dexable(?:Base)?)|teratorProtocol)|OptionSet|Un(?:signedInteger|icodeCodec)|E(?:quatable|rror|xpressibleBy(?:BooleanLiteral|String(?:Interpolation|Literal)|NilLiteral|IntegerLiteral|DictionaryLiteral|UnicodeScalarLiteral|ExtendedGraphemeClusterLiteral|FloatLiteral|ArrayLiteral))|FloatingPoint|L(?:osslessStringConvertible|azy(?:SequenceProtocol|CollectionProtocol))|A(?:nyObject|bsoluteValuable))\b
@@ -466,6 +469,9 @@ repository:
 
       - name: storage.modifier.swift
         match: \b(?:inout|isolated|borrowing|consuming)\b
+
+      - name: storage.modifier.swift
+        match: \bnonisolated(?:\(nonsending\)|\b)
 
       - name: variable.language.swift
         match: \bSelf\b
@@ -1706,7 +1712,10 @@ repository:
         match: (?<!\.)\b(class|enum|extension|precedencegroup|protocol|struct|actor)\b(?=\s*`?[\p{L}_])
 
       - name: storage.modifier.swift
-        match: (?<!\.)\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience|infix|prefix|postfix|distributed|nonisolated|borrowing|consuming)\b
+        match: (?<!\.)\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience|infix|prefix|postfix|distributed|borrowing|consuming)\b
+
+      - name: storage.modifier.swift
+        match: (?<!\.)\bnonisolated(?:\(nonsending\)|\b)
 
       - name: storage.type.function.swift
         match: \binit[?!]|\binit\b|(?<!\.)\b(?:func|deinit|subscript|didSet|get|set|willSet|yielding\s+borrow|yielding\s+mutate)\b
@@ -1727,7 +1736,7 @@ repository:
         match: (?<!\.)\b(?:super|self|Self)\b
 
       - name: support.variable.swift
-        match: \B(?:#file|#filePath|#fileID|#line|#column|#function|#dsohandle)\b|\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b
+        match: \B(?:#file|#filePath|#fileID|#line|#column|#function|#dsohandle|#isolation)\b|\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b
 
       - name: keyword.control.import.swift
         match: (?<!\.)\bimport\b

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -532,6 +532,12 @@
         <key>patterns</key>
         <array>
           <dict>
+            <key>name</key>
+            <string>support.type.swift</string>
+            <key>match</key>
+            <string>\bActor\b</string>
+          </dict>
+          <dict>
             <key>comment</key>
             <string>Protocols in the standard library in Swift 3</string>
             <key>name</key>
@@ -1356,6 +1362,12 @@
             <string>storage.modifier.swift</string>
             <key>match</key>
             <string>\b(?:inout|isolated|borrowing|consuming)\b</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>storage.modifier.swift</string>
+            <key>match</key>
+            <string>\bnonisolated(?:\(nonsending\)|\b)</string>
           </dict>
           <dict>
             <key>name</key>
@@ -4690,7 +4702,13 @@
             <key>name</key>
             <string>storage.modifier.swift</string>
             <key>match</key>
-            <string>(?&lt;!\.)\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience|infix|prefix|postfix|distributed|nonisolated|borrowing|consuming)\b</string>
+            <string>(?&lt;!\.)\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience|infix|prefix|postfix|distributed|borrowing|consuming)\b</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>storage.modifier.swift</string>
+            <key>match</key>
+            <string>(?&lt;!\.)\bnonisolated(?:\(nonsending\)|\b)</string>
           </dict>
           <dict>
             <key>name</key>
@@ -4739,7 +4757,7 @@
             <key>name</key>
             <string>support.variable.swift</string>
             <key>match</key>
-            <string>\B(?:#file|#filePath|#fileID|#line|#column|#function|#dsohandle)\b|\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b</string>
+            <string>\B(?:#file|#filePath|#fileID|#line|#column|#function|#dsohandle|#isolation)\b|\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b</string>
           </dict>
           <dict>
             <key>name</key>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -214,6 +214,9 @@ class C {
   package var package: String { }
   package func run() { }
   package(set) public var x = ""
+
+  unowned let customer: Customer
+  unowned(unsafe) let customer: Customer
 }
 
 // MARK: Actors
@@ -270,6 +273,27 @@ func foo() {
   someThread.run {
     unownedJob.runSynchronously(on: self)
   }
+}
+class NotSendable {
+  nonisolated(nonsending)
+  func performAsync() async { }
+
+  @concurrent
+  func alwaysSwitch() async { }
+}
+
+func foo(isolation: isolated (any Actor)? = #isolation) {
+  let grabActorState: nonisolated(nonsending) () async -> NotSendable = a.getState // error
+}
+public nonisolated(nonsending) func withValue<R>(
+  _ valueDuringOperation: Value,
+  operation: nonisolated(nonsending) () async throws -> R,
+  file: String = #fileID, line: UInt = #line
+) async rethrows -> R {
+  return try await withValueImpl(
+    valueDuringOperation,
+    operation: operation,
+    file: file, line: line)
 }
 
 // MARK: Extensions
@@ -1006,7 +1030,7 @@ if #unavailable(iOS 13, *) { loadMainWindow() }
 #selector(getter: MyClass.func) #selector(setter: MyClass.func)
 #keyPath(self.parent.name)
 #colorLiteral(), #imageLiteral(), #fileLiteral()
-#file, #line, #function, #dsohandle, #filePath
+#file, #line, #function, #dsohandle, #filePath, #isolation
 
 @freestanding(expression) macro stringify<T>(_: T) -> (T, String)
 

--- a/test/se-0461.test.ts
+++ b/test/se-0461.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import type { LanguageRegistration } from "shiki";
+
+import swiftGrammar from "../Swift.tmLanguage.json" with { type: "json" };
+import { $, _, createAssertScopes } from "./assert-scopes.ts";
+
+const assertScopes = await createAssertScopes(swiftGrammar as unknown as LanguageRegistration);
+
+await test("preconcurrency conformance", () => {
+  assertScopes(
+    $`class NotSendable {`,
+    _`~~~~~~~~~~~~~~~~~~~ meta.definition.type.class.swift`,
+    _`~~~~~               storage.type.class.swift`,
+    _`      ~~~~~~~~~~~   entity.name.type.class.swift`,
+    _`                  ~ meta.definition.type.body.swift, punctuation.definition.type.begin.swift`,
+    $`  nonisolated(nonsending) func performAsync() async { }`,
+    _`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ meta.definition.type.class.swift, meta.definition.type.body.swift`,
+    _`  ~~~~~~~~~~~~~~~~~~~~~~~                               storage.modifier.swift`,
+    _`                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ meta.definition.function.swift`,
+    _`                          ~~~~                          storage.type.function.swift`,
+    _`                               ~~~~~~~~~~~~             entity.name.function.swift`,
+    _`                                           ~~~~~~~~     meta.parameter-clause.swift`,
+    _`                                           ~            punctuation.definition.parameters.begin.swift`,
+    _`                                            ~           punctuation.definition.parameters.end.swift`,
+    _`                                              ~~~~~     storage.modifier.async.swift`,
+    _`                                                    ~~~ meta.definition.function.body.swift`,
+    _`                                                    ~   punctuation.section.function.begin.swift`,
+    _`                                                      ~ punctuation.section.function.end.swift`,
+    $`}`,
+    _`~ meta.definition.type.class.swift, meta.definition.type.body.swift, punctuation.definition.type.end.swift`,
+  );
+
+  assertScopes(
+    $`func foo(operation: nonisolated(nonsending) () async throws -> R) { }`,
+    _`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ meta.definition.function.swift`,
+    _`~~~~                                                                  storage.type.function.swift`,
+    _`     ~~~                                                              entity.name.function.swift`,
+    _`        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     meta.parameter-clause.swift`,
+    _`        ~                                                             punctuation.definition.parameters.begin.swift`,
+    _`         ~~~~~~~~~                                                    variable.parameter.function.swift, entity.name.function.swift`,
+    _`                    ~~~~~~~~~~~~~~~~~~~~~~~                           storage.modifier.swift`,
+    _`                                            ~                         punctuation.section.tuple-type.begin.swift`,
+    _`                                             ~                        punctuation.section.tuple-type.end.swift`,
+    _`                                               ~~~~~                  storage.modifier.async.swift`,
+    _`                                                     ~~~~~~           storage.modifier.exception.swift`,
+    _`                                                            ~~        keyword.operator.type.function.swift`,
+    _`                                                                ~     punctuation.definition.parameters.end.swift`,
+    _`                                                                  ~~~ meta.definition.function.body.swift`,
+    _`                                                                  ~   punctuation.section.function.begin.swift`,
+    _`                                                                    ~ punctuation.section.function.end.swift`,
+  );
+});


### PR DESCRIPTION
- `nonisolated(unsafe)` (fixes https://github.com/jtbandes/swift-tmlanguage/issues/49)
- `Actor` builtin protocol
- `#isolation` default argument